### PR TITLE
Replace winston with console

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
   },
   "dependencies": {
     "dotenv": "^2.0.0",
-    "lodash": "^4.3.0",
-    "winston": "^2.1.1"
+    "lodash": "^4.3.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,6 @@
 import _ from 'lodash';
 import dotenv from 'dotenv';
 import fs from 'fs';
-import winston from 'winston';
 
 function loadEnvironmentFile(path, encoding, silent) {
     try {
@@ -12,7 +11,7 @@ function loadEnvironmentFile(path, encoding, silent) {
         return dotenv.parse(data);
     } catch (err) {
         if (!silent) {
-            winston.error(err.message);
+            console.error(err.message);
         }
         return {};
     }

--- a/test/test.spec.js
+++ b/test/test.spec.js
@@ -11,7 +11,7 @@ var chai = require('chai'),
 chai.use(sinonChai);
 
 describe('dotenv-extended tests', function () {
-    var dotenvex, winstonStub;
+    var dotenvex;
 
     before(function () {
         mockery.enable({
@@ -19,11 +19,7 @@ describe('dotenv-extended tests', function () {
             warnOnUnregistered: false,
             useCleanCache: true
         });
-
-        winstonStub = {
-            error: sinon.stub()
-        };
-        mockery.registerMock('winston', winstonStub);
+        sinon.stub(console, 'error');
         dotenvex = require('../');
     });
 
@@ -108,6 +104,6 @@ describe('dotenv-extended tests', function () {
 
     it('Should log an error when silent is set to false and .env.defaults is missing', function () {
         dotenvex.load({ silent: false });
-        expect(winstonStub.error).to.have.been.calledOnce;
+        expect(console.error).to.have.been.calledOnce;
     });
 });


### PR DESCRIPTION
Thanks for a great addition to dotenv. I ran into some trouble when using it though, and here's my proposal for a fix. 

When using dotenv-extended with webpack, the compiler complains about dependencies as expressions in color.js which is used by winston and in winston itself:

```
WARNING in ./~/winston/lib/winston/transports.js
Critical dependencies:
23:17-34 the request of a dependency is an expression
 @ ./~/winston/lib/winston/transports.js 23:17-34

WARNING in ./~/winston/~/colors/lib/colors.js
Critical dependencies:
127:29-43 the request of a dependency is an expression
 @ ./~/winston/~/colors/lib/colors.js 127:29-43

WARNING in ./~/winston/~/colors/lib/extendStringPrototype.js
Critical dependencies:
106:31-45 the request of a dependency is an expression
 @ ./~/winston/~/colors/lib/extendStringPrototype.js 106:31-45
```

This is naturally an issue that needs to be addressed in winston and color.js, but since it seems a bit heavy to bring in winston as a logger only for one line of code, replacing winston with a plain old console.error in this project seems to me as a feasible solution. 