### PR TITLE
Add TypeScript types definition file

### DIFF
--- a/dotenv-extended.d.ts
+++ b/dotenv-extended.d.ts
@@ -1,0 +1,21 @@
+/// <reference types="dotenv" />
+
+export interface IEnvironmentMap {
+    [name: string]: string;
+}
+
+export interface IDotenvExtendedOptions {
+    encoding?: string;
+    silent?: boolean;
+    path?: string;
+    defaults?: string;
+    schema?: string;
+    errorOnMissing?: boolean;
+    errorOnExtra?: boolean;
+    assignToProcessEnv?: boolean;
+    overrideProcessEnv?: boolean;
+}
+
+export { parse } from 'dotenv';
+
+export function load(options?: IDotenvExtendedOptions): IEnvironmentMap;

--- a/dotenv-extended.d.ts
+++ b/dotenv-extended.d.ts
@@ -1,21 +1,91 @@
 /// <reference types="dotenv" />
 
+/**
+ * The result of a call to load() or parse()
+ */
 export interface IEnvironmentMap {
     [name: string]: string;
 }
 
+/**
+ * DotenvExtended options for load().
+ */
 export interface IDotenvExtendedOptions {
+    /**
+     * Sets the encoding of the .env files.
+     *
+     * @default 'utf-8'
+     */
     encoding?: string;
+
+    /**
+     * Sets whether a log message is shown when missing the .env or .env.defaults files.
+     *
+     * @default true
+     */
     silent?: boolean;
+
+    /**
+     * Path to the main .env file that contains your variables.
+     *
+     * @default '.env'
+     */
     path?: string;
+
+    /**
+     * The path to the file that default values are loaded from.
+     *
+     * @default '.env.defaults'
+     */
     defaults?: string;
+
+    /**
+     * The path to the file that contains the schema of what values should be available
+     * from combining .env and .env.defaults.
+     *
+     * @default '.env.schema'
+     */
     schema?: string;
+
+    /**
+     * Causes the library to throw a MISSING CONFIG VALUES error listing all of the variables
+     * missing the combined .env and .env.defaults files.
+     *
+     * @default false
+     */
     errorOnMissing?: boolean;
+
+    /**
+     * Causes the library to throw a EXTRA CONFIG VALUES error listing all of the extra variables
+     * from the combined .env and .env.defaults files.
+     *
+     * @default false
+     */
     errorOnExtra?: boolean;
+
+    /**
+     * Sets whether the loaded values are assigned to the process.env object.
+     * If this is set, you must capture the return value of the call to .load() or you will not be
+     * able to use your variables.
+     *
+     * @default true
+     */
     assignToProcessEnv?: boolean;
+
+    /**
+     * By defaut, dotenv-entended will not overwrite any varibles that are already set in the process.env object.
+     * If you would like to enable overwriting any already existing values, set this value to true.
+     *
+     * @default false
+     */
     overrideProcessEnv?: boolean;
 }
 
 export { parse } from 'dotenv';
 
+/**
+ * Loads the dotenv files, .env, .env.defaults and .env.schema.
+ *
+ * @param options
+ */
 export function load(options?: IDotenvExtendedOptions): IEnvironmentMap;

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "A module for loading .env files and optionally loading defaults and a schema for validating all values are present.",
   "repository": "git@github.com:keithmorris/node-dotenv-extended.git",
   "main": "lib/index.js",
+  "types": "dotenv-extended.d.ts",
   "bin": "lib/bin/index.js",
   "scripts": {
     "test": "gulp unittest",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     ]
   },
   "dependencies": {
+    "@types/dotenv": "^4.0.0",
     "auto-parse": "^1.3.0",
     "camelcase": "^4.1.0",
     "cross-spawn": "^5.1.0",


### PR DESCRIPTION
Hello @keithmorris,

I'm happy to propose you a types declaration file for TypeScript.
If you're unfamiliar with TypeScript, that lets API consumers to use dotenv-extended in a type-safe manner.

I could have published the types on DefinitelyTyped, but embedded types are much more practical and are easier to sync when the JavaScript changes.
In fact, bundling types with the original JavaScript library is recommended by the official documentation:

> If you control the npm package you are publishing declarations for, then the first approach is favored. That way, your declarations and JavaScript always travel together.
http://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html

> If you are the library author, or can make a pull request to the library, bundle types instead of publishing to DefinitelyTyped.
https://github.com/DefinitelyTyped/DefinitelyTyped

I've used dotenv-extended in a few projects now and I'm tired to have to stub the types each time :)

Thanks for your work, and I hope you will merge this (I can help to maintain!).