### PR TITLE
Fix process.env overrided by default using cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Common configuration defaults across all environments (commited to source contro
 
 ### `.env.schema`
 
-Defines a schema of what variables _should_ be defined in the combination of `.env` and `.env.defaults`. Optionally, you can have the libarary throw and error if all values are not configured or if there are extra values that shouldn't be there.
+Defines a schema of what variables _should_ be defined in the combination of `.env` and `.env.defaults`. Optionally, you can have the library throw an error if all values are not configured or if there are extra values that shouldn't be there.
 
 
 The `.env.schema` file should only have the name of the variable and the `=` without any value:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dotenv-extended-lonestone",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "temporary fork of dotenv-extended",
   "repository": "git@github.com:lonestone/node-dotenv-extended.git",
   "main": "lib/index.js",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "dotenv-extended",
-  "version": "2.0.1",
-  "description": "A module for loading .env files and optionally loading defaults and a schema for validating all values are present.",
-  "repository": "git@github.com:keithmorris/node-dotenv-extended.git",
+  "name": "dotenv-extended-lonestone",
+  "version": "2.0.2",
+  "description": "temporary fork of dotenv-extended",
+  "repository": "git@github.com:lonestone/node-dotenv-extended.git",
   "main": "lib/index.js",
   "types": "dotenv-extended.d.ts",
   "bin": "lib/bin/index.js",
@@ -16,7 +16,7 @@
     "dotenv",
     "environment"
   ],
-  "author": "Keith Morris <standupbass@gmail.com> (http://standupbass.wordpress.com/)",
+  "author": "gabriel <gabriel@lonetone.studio>",
   "license": "MIT",
   "devDependencies": {
     "babel-eslint": "^7.2.3",


### PR DESCRIPTION
Why 
Using cli, process.env is overrided by .env.defaults. Expected behavior is the opposite.