### PR TITLE
Add errorCheckProcess flag to handle process.env on errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ The following are the flags you can pass to the `dotenv-extended` cli with their
 --schema=.env.schema
 --errorOnMissing=false     # or --error-on-missing=false
 --errorOnExtra=false       # or --error-on-extra=false
---errorCheckProcess=false       # or --error-check-process=false
+--includeProcessEnv=false       # or --error-check-process=false
 --assignToProcessEnv=true  # or --assign-to-process-env=true
 --overrideProcessEnv=false # or --override-process-env=true
 ```
@@ -139,7 +139,7 @@ require('dotenv-extended').load({
 	schema: '.env.schema',
 	errorOnMissing: false,
 	errorOnExtra: false,
-	errorCheckProcess: false,
+	includeProcessEnv: false,
 	assignToProcessEnv: true,
 	overrideProcessEnv: false
 });
@@ -179,7 +179,7 @@ Causes the library to throw a `MISSING CONFIG VALUES` error listing all of the v
 
 Causes the library to throw a `EXTRA CONFIG VALUES` error listing all of the extra variables from the combined `.env` and `.env.defaults` files.
 
-### errorCheckProcess (_default: false_)
+### includeProcessEnv (_default: false_)
 
 Causes the library add process.env variables to error checking. The variables in process.env overrides the variables in .env and .env.defaults while checking
 

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ The following are the flags you can pass to the `dotenv-extended` cli with their
 --schema=.env.schema
 --errorOnMissing=false     # or --error-on-missing=false
 --errorOnExtra=false       # or --error-on-extra=false
+--errorCheckProcess=false       # or --error-check-process=false
 --assignToProcessEnv=true  # or --assign-to-process-env=true
 --overrideProcessEnv=false # or --override-process-env=true
 ```
@@ -138,6 +139,7 @@ require('dotenv-extended').load({
 	schema: '.env.schema',
 	errorOnMissing: false,
 	errorOnExtra: false,
+	errorCheckProcess: false,
 	assignToProcessEnv: true,
 	overrideProcessEnv: false
 });
@@ -176,6 +178,10 @@ Causes the library to throw a `MISSING CONFIG VALUES` error listing all of the v
 ### errorOnExtra (_default: false_)
 
 Causes the library to throw a `EXTRA CONFIG VALUES` error listing all of the extra variables from the combined `.env` and `.env.defaults` files.
+
+### errorCheckProcess (_default: false_)
+
+Causes the library add process.env variables to error checking. The variables in process.env overrides the variables in .env and .env.defaults while checking
 
 ### assignToProcessEnv (_default: true_)
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ The following are the flags you can pass to the `dotenv-extended` cli with their
 --schema=.env.schema
 --errorOnMissing=false     # or --error-on-missing=false
 --errorOnExtra=false       # or --error-on-extra=false
---includeProcessEnv=false       # or --error-check-process=false
+--includeProcessEnv=false  # or --include-process-env=false
 --assignToProcessEnv=true  # or --assign-to-process-env=true
 --overrideProcessEnv=false # or --override-process-env=true
 ```

--- a/dotenv-extended.d.ts
+++ b/dotenv-extended.d.ts
@@ -64,6 +64,14 @@ export interface IDotenvExtendedOptions {
     errorOnExtra?: boolean;
 
     /**
+     * Causes the library add process.env variables to error checking. The variables in process.env overrides the 
+     * variables in .env and .env.defaults while checking
+     *
+     * @default false
+     */
+    errorCheckProcess?: boolean;
+
+    /**
      * Sets whether the loaded values are assigned to the process.env object.
      * If this is set, you must capture the return value of the call to .load() or you will not be
      * able to use your variables.

--- a/dotenv-extended.d.ts
+++ b/dotenv-extended.d.ts
@@ -69,7 +69,7 @@ export interface IDotenvExtendedOptions {
      *
      * @default false
      */
-    errorCheckProcess?: boolean;
+    includeProcessEnv?: boolean;
 
     /**
      * Sets whether the loaded values are assigned to the process.env object.

--- a/src/index.js
+++ b/src/index.js
@@ -28,7 +28,7 @@ export const config = options => {
             schema: '.env.schema',
             errorOnMissing: false,
             errorOnExtra: false,
-            errorCheckProcess: false,
+            includeProcessEnv: false,
             assignToProcessEnv: true,
             overrideProcessEnv: false
         };
@@ -42,7 +42,7 @@ export const config = options => {
 
     if (options.errorOnMissing || options.errorOnExtra) {
         let schemaKeys = _.keys(loadEnvironmentFile(options.schema, options.encoding, options.silent));
-        let configKeys = options.errorCheckProcess ? _.keys(_.assign({}, configData, process.env)) : _.keys(configData);
+        let configKeys = options.includeProcessEnv ? _.keys(_.assign({}, configData, process.env)) : _.keys(configData);
 
         let missingKeys = _.filter(schemaKeys, function (key) {
             return configKeys.indexOf(key) < 0;

--- a/src/index.js
+++ b/src/index.js
@@ -28,6 +28,7 @@ export const config = options => {
             schema: '.env.schema',
             errorOnMissing: false,
             errorOnExtra: false,
+            errorCheckProcess: false,
             assignToProcessEnv: true,
             overrideProcessEnv: false
         };
@@ -41,7 +42,7 @@ export const config = options => {
 
     if (options.errorOnMissing || options.errorOnExtra) {
         let schemaKeys = _.keys(loadEnvironmentFile(options.schema, options.encoding, options.silent));
-        let configKeys = _.keys(configData);
+        let configKeys = options.errorCheckProcess ? _.keys(_.assign({}, configData, process.env)) : _.keys(configData);
 
         let missingKeys = _.filter(schemaKeys, function (key) {
             return configKeys.indexOf(key) < 0;

--- a/test/test.spec.js
+++ b/test/test.spec.js
@@ -69,10 +69,10 @@ describe('dotenv-extended tests', function () {
         expect(runTest).to.throw(Error);
     });
 
-    it('Should process process.env variables before checking errors when errorCheckProcess is true', function () {
+    it('Should process process.env variables before checking errors when includeProcessEnv is true', function () {
         process.env.TEST_TWO = 'two';
         process.env.TEST_THREE = 'three';
-        dotenvex.load({ schema: '.env.schema.example', errorCheckProcess: true });
+        dotenvex.load({ schema: '.env.schema.example', includeProcessEnv: true });
         expect(process.env.TEST_TWO).to.equal('two');
     });
 

--- a/test/test.spec.js
+++ b/test/test.spec.js
@@ -69,6 +69,13 @@ describe('dotenv-extended tests', function () {
         expect(runTest).to.throw(Error);
     });
 
+    it('Should process process.env variables before checking errors when errorCheckProcess is true', function () {
+        process.env.TEST_TWO = 'two';
+        process.env.TEST_THREE = 'three';
+        dotenvex.load({ schema: '.env.schema.example', errorCheckProcess: true });
+        expect(process.env.TEST_TWO).to.equal('two');
+    });
+
     it('Should load schema, defaults and env into correct values in process.env and returned object', function () {
         var config = dotenvex.load({
             schema: '.env.schema.example',


### PR DESCRIPTION
Adds a flag to let configKeys to be overridden by process.env when processing errors. This implements #17 while maintaining backwards compatibility.