### PR TITLE
fix: expose entire process.env to command called with CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,13 +102,13 @@ npm install -g dotenv-extended
 Now call your shell scripts through `dotenv-extended` (this uses the defaults):
 
 ```
-dotenv-extended myshellscript.sh --whatever-flags-my-script-takes
+dotenv-extended ./myshellscript.sh --whatever-flags-my-script-takes
 ```
 
 Configure `dotenv-extended` by passing any of the dotenv-extended options before your command. Preceed each option with two dashes `--`:
 
 ```
-dotenv-extended --path=/path/to/.env --defaults=/path/to/.env.defaults --errorOnMissing=true myshellscript.sh --whatever-flags-my-script-takes
+dotenv-extended --path=/path/to/.env --defaults=/path/to/.env.defaults --errorOnMissing=true ./myshellscript.sh --whatever-flags-my-script-takes
 ```
 
 The following are the flags you can pass to the `dotenv-extended` cli with their default values. these options detailed later in this document:

--- a/src/bin/index.js
+++ b/src/bin/index.js
@@ -13,10 +13,11 @@ import {spawn} from 'cross-spawn';
 function loadAndExecute(args) {
     const [dotEnvConfig, command, commandArgs] = parseCommand(args);
     if (command) {
+        config(dotEnvConfig); // mutates process.env
         const proc = spawn(command, commandArgs, {
             stdio: 'inherit',
             shell: true,
-            env: config(dotEnvConfig),
+            env: process.env,
         });
 
         process.on('SIGTERM', () => proc.kill('SIGTERM'));


### PR DESCRIPTION
Closes #23, the `spawn` function was mistakenly given only the changes in the environment due to `.env` etc, instead of the entire `process.env`.

Note that the CLI command must be called as `dotenv-extended ./script.sh`, I previously had `dotenv-extended script.sh` but that is equivalent to running `script.sh` in the terminal, which does not work. AFAIK the commands in the README should not work, so I changed them as well.

Giving `shell: false` to `cross-spawn` would enable using `dotenv-extended script.sh` (I think) but that broke the code in some other way. https://github.com/kentcdodds/cross-env/#cross-env-vs-cross-env-shell might be relevant to this.