### PR TITLE
[Feature proposal] Use .d.ts as schema for type safety

### DIFF
--- a/dotenv-extended.d.ts
+++ b/dotenv-extended.d.ts
@@ -4,7 +4,7 @@
  * The result of a call to load() or parse()
  */
 export interface IEnvironmentMap {
-    [name: string]: string;
+    [name: string]: string | undefined;
 }
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -9497,6 +9497,11 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
+    "typescript": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+      "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w=="
+    },
     "typpy": {
       "version": "2.3.11",
       "resolved": "https://registry.npmjs.org/typpy/-/typpy-2.3.11.tgz",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "auto-parse": "^1.3.0",
     "camelcase": "^5.3.1",
     "cross-spawn": "^7.0.1",
-    "dotenv": "^8.2.0"
+    "dotenv": "^8.2.0",
+    "typescript": "^3.8.3"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@
 import dotenv from 'dotenv';
 import getConfigFromEnv from './utils/config-from-env';
 import loadEnvironmentFile from './utils/load-environment-file';
+import loadEnvTypeDeclaration from './utils/load-env-type-declaration';
 
 export const parse = dotenv.parse.bind(dotenv);
 export const config = options => {
@@ -35,7 +36,9 @@ export const config = options => {
     const configKeys = Object.keys(config);
 
     if (options.errorOnMissing || options.errorOnExtra || options.errorOnRegex) {
-        const schema = loadEnvironmentFile(options.schema, options.encoding, options.silent);
+        const schema = options.schema.endsWith('.d.ts') ? 
+            loadEnvTypeDeclaration(options.schema, options.encoding, options.silent)
+            : loadEnvironmentFile(options.schema, options.encoding, options.silent);
         const schemaKeys = Object.keys(schema);
 
         let missingKeys = schemaKeys.filter(function (key) {

--- a/src/utils/load-env-type-declaration.js
+++ b/src/utils/load-env-type-declaration.js
@@ -1,0 +1,25 @@
+import fs from 'fs';
+import ts from 'typescript';
+
+export const loadEnvTypeDeclaration = (path, encoding, silent) => {
+    try {
+        const data = fs.readFileSync(path, encoding);
+        const source = ts.createSourceFile(path, data, ts.ScriptTarget.ES2015, true);
+        const schema = {};
+        source.getChildren().find(c => c.kind === ts.SyntaxKind.SyntaxList).getChildren()
+            .find(c => c.kind === ts.SyntaxKind.ModuleDeclaration && c.name.text === 'dotenv-extended').body.getChildren()
+            .find(c => c.kind === ts.SyntaxKind.SyntaxList).getChildren()
+            .find(c => c.kind === ts.SyntaxKind.InterfaceDeclaration && c.name.escapedText === 'IEnvironmentMap').getChildren()
+            .find(c => c.kind === ts.SyntaxKind.SyntaxList).getChildren()
+            // Only accepts members of type "string"
+            .filter(c => c.type.kind === ts.SyntaxKind.StringKeyword)
+            .forEach(c => schema[c.name.escapedText] = '');
+        return schema;
+    } catch (err) {
+        if (!silent) {
+            console.error(err.message);
+        }
+        return {};
+    }
+};
+export default loadEnvTypeDeclaration;

--- a/test/EnvSchema.d.ts
+++ b/test/EnvSchema.d.ts
@@ -1,0 +1,15 @@
+import { IEnvironmentMap } from "dotenv-extended";
+
+declare module "dotenv-extended" {
+  interface IEnvironmentMap {
+    TEST_ONE: string;
+    TEST_TWO: string;
+    TEST_THREE: string;
+  }
+}
+
+declare global{
+  namespace NodeJS {
+    interface ProcessEnv extends IEnvironmentMap {}
+  }
+}

--- a/test/test.spec.js
+++ b/test/test.spec.js
@@ -167,6 +167,22 @@ describe('dotenv-extended tests', () => {
         dotenvex.load({silent: false});
         expect(console.error).to.have.been.calledOnce;
     });
+
+    it('Should load .d.ts schema, defaults and env into correct values in process.env and returned object', function () {
+        const config = dotenvex.load({
+            schema: 'EnvSchema.d.ts',
+            defaults: '.env.defaults.example',
+            path: '.env.override',
+            errorOnExtra: true,
+            errorOnMissing: true
+        });
+        expect(config.TEST_ONE).to.equal('one overridden');
+        expect(config.TEST_TWO).to.equal('two');
+        expect(config.TEST_THREE).to.equal('three');
+        expect(process.env.TEST_ONE).to.equal('one overridden');
+        expect(process.env.TEST_TWO).to.equal('two');
+        expect(process.env.TEST_THREE).to.equal('three');
+    });
 });
 
 describe('Supporting libraries tests', () => {


### PR DESCRIPTION
This proposal adds type safety for typescript by providing the ability to use type declarations directly as a schema. With schema checking, we can take advantage of the fact that this library ensures the respective keys in `process.env` will be present. 

Existing solutions are not as great. We could litter the typescript code with `if KEY !== undefined` or with `!!` operator but risk having typographical errors. Having `process.env`  type declaration facilitates code completion. While we can use a type declaration separate from the schema, being able to have one single source of truth avoids the need to change multiple places. 

Notes
1. README not updated
2. Union string types not supported, future additions could include that with checking
3. I have also considered declaration code generation but it can be painful for a small project without proper build pipelines

**Breaks:** type declaration of IEnvironmentMap changed to `{ [name: string]: string | undefined }`. I believe `dotenv`'s type declaration of `{ [name: string]: string }` is a mistake. With this change, it no longer makes sense to carry this mistake down.