### PR TITLE
Missing values should default to empty strings for errorOnRegex

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -55,7 +55,7 @@ export const config = options => {
         if (options.errorOnRegex) {
             const regexMismatchKeys = schemaKeys.filter(function (key) {
                 if (schema[key]) {
-                    return !new RegExp(schema[key]).test(config[key]);
+                    return !new RegExp(schema[key]).test(typeof config[key] === 'string' ? config[key] : '');
                 }
             });
 

--- a/test/.env.schema.regex-optional
+++ b/test/.env.schema.regex-optional
@@ -1,0 +1,5 @@
+TEST_VAR=^my test var$
+TEST_ONE=^overridden$
+
+TEST_MISSING_OPTIONAL=^(optional)?$
+TEST_MISSING_REQUIRED=^optional$

--- a/test/test.spec.js
+++ b/test/test.spec.js
@@ -163,6 +163,16 @@ describe('dotenv-extended tests', () => {
         expect(runTest).to.throw('REGEX MISMATCH: TEST_TWO, TEST_THREE');
     });
 
+    it('Should default missing values to empty string when errorOnRegex is true', () => {
+        const runTest = () => {
+            dotenvex.load({
+                schema: '.env.schema.regex-optional',
+                errorOnRegex: true,
+            });
+        };
+        expect(runTest).to.throw('REGEX MISMATCH: TEST_MISSING_REQUIRED');
+    });
+
     it('Should log an error when silent is set to false and .env.defaults is missing', function () {
         dotenvex.load({silent: false});
         expect(console.error).to.have.been.calledOnce;


### PR DESCRIPTION
IMO the `RegExp().test()` for `errorOnRegex` should default missing - or actually any non-string - values to `""`.

Currently, `^(true|undefined)$` is required to require a variable to either be `"true"` or not set. This feels hacky as it relies on `RegExp().test()` casting non-string values to a string, in which case `undefined` becomes `"undefined"`.

As environment variables should always be strings, I think it's better to default non-strings to `""` so that you can use `^(true)?$` to require a value to either be `"true"` or not set.

Without the change in `src/index.js` the newly added test fails with:

```
      AssertionError: expected [Function: runTest] to throw error including 'REGEX MISMATCH: TEST_MISSING_REQUIRED' but got 'REGEX MISMATCH: TEST_MISSING_OPTIONAL, TEST_MISSING_REQUIRED'
      + expected - actual

      -REGEX MISMATCH: TEST_MISSING_OPTIONAL, TEST_MISSING_REQUIRED
      +REGEX MISMATCH: TEST_MISSING_REQUIRED
```

Also see #41